### PR TITLE
Add support for file marking

### DIFF
--- a/core/command_test.go
+++ b/core/command_test.go
@@ -6,11 +6,11 @@ import (
 )
 
 func TestStatePath(t *testing.T) {
-	subTree := &File{"c", 50, true, []*File{
-		&File{"d", 50, false, []*File{}},
+	subTree := &File{"c", nil, 50, true, []*File{
+		&File{"d", nil, 50, false, []*File{}},
 	}}
-	tree := &File{"a", 50, true, []*File{
-		&File{"b", 50, false, []*File{}},
+	tree := &File{"a", nil, 50, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
 		subTree,
 	}}
 	initialState := State{
@@ -24,9 +24,9 @@ func TestStatePath(t *testing.T) {
 }
 
 func TestDownCommand(t *testing.T) {
-	tree := &File{"a", 100, true, []*File{
-		&File{"b", 50, false, []*File{}},
-		&File{"c", 50, false, []*File{}},
+	tree := &File{"a", nil, 100, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
+		&File{"c", nil, 50, false, []*File{}},
 	}}
 	initialState := State{
 		Folder: tree,
@@ -39,9 +39,9 @@ func TestDownCommand(t *testing.T) {
 }
 
 func TestDownCommandFails(t *testing.T) {
-	tree := &File{"a", 100, true, []*File{
-		&File{"b", 50, false, []*File{}},
-		&File{"c", 50, false, []*File{}},
+	tree := &File{"a", nil, 100, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
+		&File{"c", nil, 50, false, []*File{}},
 	}}
 	initialState := State{
 		Folder:   tree,
@@ -58,13 +58,13 @@ func TestDownCommandFails(t *testing.T) {
 }
 
 func TestUpCommand(t *testing.T) {
-	tree := &File{"a", 100, true, []*File{
-		&File{"b", 50, true, []*File{}},
-		&File{"c", 50, true, []*File{}},
+	tree := &File{"a", nil, 100, true, []*File{
+		&File{"b", nil, 50, true, []*File{}},
+		&File{"c", nil, 50, true, []*File{}},
 	}}
 	initialState := State{
-		Selected: 1,
 		Folder:   tree,
+		Selected: 1,
 	}
 	newState, _ := Up{}.Execute(initialState)
 	if newState.Selected != 0 {
@@ -74,9 +74,9 @@ func TestUpCommand(t *testing.T) {
 }
 
 func TestUpCommandFails(t *testing.T) {
-	tree := &File{"a", 100, true, []*File{
-		&File{"b", 50, true, []*File{}},
-		&File{"c", 50, true, []*File{}},
+	tree := &File{"a", nil, 100, true, []*File{
+		&File{"b", nil, 50, true, []*File{}},
+		&File{"c", nil, 50, true, []*File{}},
 	}}
 	initialState := State{
 		Folder:   tree,
@@ -93,26 +93,29 @@ func TestUpCommandFails(t *testing.T) {
 }
 
 func TestEnterCommand(t *testing.T) {
-	subTree := &File{"c", 50, true, []*File{
-		&File{"d", 50, false, []*File{}},
-		&File{"f", 50, false, []*File{}},
+	subTree := &File{"c", nil, 50, true, []*File{
+		&File{"d", nil, 50, false, []*File{}},
+		&File{"f", nil, 50, false, []*File{}},
 	}}
-	tree := &File{"a", 50, true, []*File{
-		&File{"b", 50, false, []*File{}},
+	tree := &File{"a", nil, 50, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
 		subTree,
 	}}
+	marked := make(map[*File]struct{})
 	initialState := State{
-		Selected: 1,
-		Folder:   tree,
-		history:  map[*File]int{subTree: 1},
+		Folder:      tree,
+		history:     map[*File]int{subTree: 1},
+		Selected:    1,
+		MarkedFiles: marked,
 	}
 	command := Enter{}
 	newState, _ := command.Execute(initialState)
 	expectedState := State{
-		ancestors: ancestors{tree},
-		Folder:    subTree,
-		history:   map[*File]int{tree: 1, subTree: 1},
-		Selected:  1,
+		ancestors:   ancestors{tree},
+		Folder:      subTree,
+		history:     map[*File]int{tree: 1, subTree: 1},
+		Selected:    1,
+		MarkedFiles: marked,
 	}
 	if !reflect.DeepEqual(newState, expectedState) {
 		t.Errorf("New state is not same as expected %v and %v", newState, expectedState)
@@ -120,8 +123,8 @@ func TestEnterCommand(t *testing.T) {
 }
 
 func TestEnterCommandFails(t *testing.T) {
-	tree := &File{"a", 50, true, []*File{
-		&File{"b", 50, false, []*File{}},
+	tree := &File{"a", nil, 50, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
 	}}
 	initialState := State{
 		Folder: tree,
@@ -135,27 +138,30 @@ func TestEnterCommandFails(t *testing.T) {
 }
 
 func TestGoBackCommand(t *testing.T) {
-	subTree := &File{"c", 50, true, []*File{
-		&File{"d", 50, false, []*File{}},
-		&File{"e", 50, false, []*File{}},
+	subTree := &File{"c", nil, 50, true, []*File{
+		&File{"d", nil, 50, false, []*File{}},
+		&File{"e", nil, 50, false, []*File{}},
 	}}
-	tree := &File{"a", 50, true, []*File{
-		&File{"b", 50, false, []*File{}},
+	tree := &File{"a", nil, 50, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
 		subTree,
 	}}
+	marked := make(map[*File]struct{})
 	initialState := State{
-		ancestors: ancestors{tree},
-		Folder:    subTree,
-		Selected:  1,
-		history:   map[*File]int{tree: 1},
+		ancestors:   ancestors{tree},
+		Folder:      subTree,
+		history:     map[*File]int{tree: 1},
+		Selected:    1,
+		MarkedFiles: marked,
 	}
 	command := GoBack{}
 	newState, _ := command.Execute(initialState)
 	expectedState := State{
-		ancestors: ancestors{},
-		Folder:    tree,
-		history:   map[*File]int{tree: 1, subTree: 1},
-		Selected:  1,
+		ancestors:   ancestors{},
+		Folder:      tree,
+		history:     map[*File]int{tree: 1, subTree: 1},
+		Selected:    1,
+		MarkedFiles: marked,
 	}
 	if !reflect.DeepEqual(newState, expectedState) {
 		t.Errorf("New state is not same as expected %v and %v", newState, expectedState)
@@ -163,8 +169,8 @@ func TestGoBackCommand(t *testing.T) {
 }
 
 func TestGoBackOnRoot(t *testing.T) {
-	tree := &File{"a", 50, true, []*File{
-		&File{"b", 50, false, []*File{}},
+	tree := &File{"a", nil, 50, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
 	}}
 	initialState := State{
 		ancestors: ancestors{},
@@ -174,5 +180,26 @@ func TestGoBackOnRoot(t *testing.T) {
 	_, err := command.Execute(initialState)
 	if err == nil {
 		t.Error("GoBack should fail on root")
+	}
+}
+
+func TestMarkFile(t *testing.T) {
+	tree := &File{"a", nil, 50, true, []*File{
+		&File{"b", nil, 50, false, []*File{}},
+	}}
+	initialState := State{
+		ancestors:   ancestors{},
+		Folder:      tree,
+		Selected:    0,
+		MarkedFiles: make(map[*File]struct{}),
+	}
+	command := Mark{}
+	newState, _ := command.Execute(initialState)
+	if _, marked := newState.MarkedFiles[tree.Files[0]]; !marked {
+		t.Error("File is not marked but should be")
+	}
+	newState, _ = command.Execute(newState)
+	if _, marked := newState.MarkedFiles[tree.Files[0]]; marked {
+		t.Error("File is marked but shouldn't be")
 	}
 }

--- a/core/file_walker.go
+++ b/core/file_walker.go
@@ -1,37 +1,50 @@
 package core
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 )
 
 type File struct {
-	Name  string
-	Size  int64
-	IsDir bool
-	Files []*File
+	Name   string
+	Parent *File
+	Size   int64
+	IsDir  bool
+	Files  []*File
+}
+
+func (f *File) Path() string {
+	var path string
+	cur := f
+	for {
+		if cur = cur.Parent; cur == nil {
+			break
+		}
+		path = filepath.Join(cur.Name, path)
+	}
+	return filepath.Join(path, f.Name)
 }
 
 type ReadDir func(dirname string) ([]os.FileInfo, error)
 
-func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}) *File {
+func GetSubTree(path string, parent *File, readDir ReadDir, ignoredFolders map[string]struct{}) *File {
 	_, name := filepath.Split(path)
+	ret := &File{}
 	entries, err := readDir(path)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "godu: %v\n", err)
-		return &File{}
+		log.Println(err)
+		return ret
 	}
 	files := make([]*File, 0, len(entries))
 	var folderSize int64
 	for _, entry := range entries {
 		if entry.IsDir() {
-			_, ignored := ignoredFolders[entry.Name()]
-			if ignored {
+			if _, ignored := ignoredFolders[entry.Name()]; ignored {
 				continue
 			}
 			subDir := filepath.Join(path, entry.Name())
-			subfolder := GetSubTree(subDir, readDir, ignoredFolders)
+			subfolder := GetSubTree(subDir, ret, readDir, ignoredFolders)
 			folderSize += subfolder.Size
 			files = append(files, subfolder)
 		} else {
@@ -39,6 +52,7 @@ func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}
 			folderSize += size
 			file := &File{
 				entry.Name(),
+				ret,
 				size,
 				false,
 				[]*File{},
@@ -46,5 +60,12 @@ func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}
 			files = append(files, file)
 		}
 	}
-	return &File{name, folderSize, true, files}
+	ret.Name = name
+	if parent != nil {
+		ret.Parent = parent
+	}
+	ret.Size = folderSize
+	ret.IsDir = true
+	ret.Files = files
+	return ret
 }

--- a/core/processor_test.go
+++ b/core/processor_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 func TestPrepareTree(t *testing.T) {
-	tree := &File{"a", 130, true, []*File{
-		&File{"b", 10, false, []*File{}},
-		&File{"c", 50, false, []*File{}},
-		&File{"d", 70, false, []*File{}},
+	tree := &File{"a", nil, 130, true, []*File{
+		&File{"b", nil, 10, false, []*File{}},
+		&File{"c", nil, 50, false, []*File{}},
+		&File{"d", nil, 70, false, []*File{}},
 	}}
 	PrepareTree(tree, 30)
-	expected := &File{"a", 130, true, []*File{
-		&File{"d", 70, false, []*File{}},
-		&File{"c", 50, false, []*File{}},
+	expected := &File{"a", nil, 130, true, []*File{
+		&File{"d", nil, 70, false, []*File{}},
+		&File{"c", nil, 50, false, []*File{}},
 	}}
 	if !reflect.DeepEqual(*tree, *expected) {
 		t.Error("PrepareTree didn't prune and sort tree")
@@ -23,8 +23,8 @@ func TestPrepareTree(t *testing.T) {
 }
 
 func TestPrepareTreeShouldFailWithSmallFiles(t *testing.T) {
-	tree := &File{"a", 70, true, []*File{
-		&File{"b", 70, false, []*File{}},
+	tree := &File{"a", nil, 70, true, []*File{
+		&File{"b", nil, 70, false, []*File{}},
 	}}
 	err := PrepareTree(tree, 80)
 	if err == nil {
@@ -35,13 +35,14 @@ func TestPrepareTreeShouldFailWithSmallFiles(t *testing.T) {
 func TestStartProcessing(t *testing.T) {
 	commands := make(chan Executer)
 	states := make(chan State, 2)
-	tree := &File{"a", 60, true, []*File{
-		&File{"b", 10, false, []*File{}},
-		&File{"c", 50, false, []*File{}},
+	lastStateChan := make(chan<- *State, 1)
+	tree := &File{"a", nil, 60, true, []*File{
+		&File{"b", nil, 10, false, []*File{}},
+		&File{"c", nil, 50, false, []*File{}},
 	}}
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go StartProcessing(tree, commands, states, &wg)
+	go StartProcessing(tree, commands, states, lastStateChan, &wg)
 	commands <- Down{}
 	close(commands)
 	state := <-states
@@ -59,13 +60,14 @@ func TestStartProcessing(t *testing.T) {
 func TestDoesntProcessInvalidCommand(t *testing.T) {
 	commands := make(chan Executer)
 	states := make(chan State)
+	lastStateChan := make(chan<- *State, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	tree := &File{"a", 60, true, []*File{
-		&File{"b", 10, false, []*File{}},
-		&File{"c", 50, false, []*File{}},
+	tree := &File{"a", nil, 60, true, []*File{
+		&File{"b", nil, 10, false, []*File{}},
+		&File{"c", nil, 50, false, []*File{}},
 	}}
-	go StartProcessing(tree, commands, states, &wg)
+	go StartProcessing(tree, commands, states, lastStateChan, &wg)
 	<-states
 	commands <- Enter{}
 	close(commands)

--- a/core/tree_manipulation_test.go
+++ b/core/tree_manipulation_test.go
@@ -6,27 +6,27 @@ import (
 )
 
 func TestSortTree(t *testing.T) {
-	testTree := &File{"b", 260, true, []*File{
-		&File{"c", 100, false, []*File{}},
-		&File{"d", 160, true, []*File{
-			&File{"e", 50, false, []*File{}},
-			&File{"f", 30, false, []*File{}},
-			&File{"g", 80, true, []*File{
-				&File{"i", 30, false, []*File{}},
-				&File{"j", 50, false, []*File{}},
+	testTree := &File{"b", nil, 260, true, []*File{
+		&File{"c", nil, 100, false, []*File{}},
+		&File{"d", nil, 160, true, []*File{
+			&File{"e", nil, 50, false, []*File{}},
+			&File{"f", nil, 30, false, []*File{}},
+			&File{"g", nil, 80, true, []*File{
+				&File{"i", nil, 30, false, []*File{}},
+				&File{"j", nil, 50, false, []*File{}},
 			}},
 		}},
 	}}
-	expected := &File{"b", 260, true, []*File{
-		&File{"d", 160, true, []*File{
-			&File{"g", 80, true, []*File{
-				&File{"j", 50, false, []*File{}},
-				&File{"i", 30, false, []*File{}},
+	expected := &File{"b", nil, 260, true, []*File{
+		&File{"d", nil, 160, true, []*File{
+			&File{"g", nil, 80, true, []*File{
+				&File{"j", nil, 50, false, []*File{}},
+				&File{"i", nil, 30, false, []*File{}},
 			}},
-			&File{"e", 50, false, []*File{}},
-			&File{"f", 30, false, []*File{}},
+			&File{"e", nil, 50, false, []*File{}},
+			&File{"f", nil, 30, false, []*File{}},
 		}},
-		&File{"c", 100, false, []*File{}},
+		&File{"c", nil, 100, false, []*File{}},
 	}}
 	SortDesc(testTree)
 	if !reflect.DeepEqual(testTree, expected) {
@@ -35,21 +35,21 @@ func TestSortTree(t *testing.T) {
 }
 
 func TestPruneTree(t *testing.T) {
-	testTree := &File{"b", 260, true, []*File{
-		&File{"c", 100, false, []*File{}},
-		&File{"d", 160, true, []*File{
-			&File{"e", 50, false, []*File{}},
-			&File{"f", 30, false, []*File{}},
-			&File{"g", 80, true, []*File{
-				&File{"i", 50, false, []*File{}},
-				&File{"j", 30, false, []*File{}},
+	testTree := &File{"b", nil, 260, true, []*File{
+		&File{"c", nil, 100, false, []*File{}},
+		&File{"d", nil, 160, true, []*File{
+			&File{"e", nil, 50, false, []*File{}},
+			&File{"f", nil, 30, false, []*File{}},
+			&File{"g", nil, 80, true, []*File{
+				&File{"i", nil, 50, false, []*File{}},
+				&File{"j", nil, 30, false, []*File{}},
 			}},
 		}},
 	}}
-	expected := &File{"b", 260, true, []*File{
-		&File{"c", 100, false, []*File{}},
-		&File{"d", 160, true, []*File{
-			&File{"g", 80, true, []*File{}},
+	expected := &File{"b", nil, 260, true, []*File{
+		&File{"c", nil, 100, false, []*File{}},
+		&File{"d", nil, 160, true, []*File{
+			&File{"g", nil, 80, true, []*File{}},
 		}},
 	}}
 	PruneTree(testTree, 60)

--- a/ignore.go
+++ b/ignore.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bufio"
-	"fmt"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -11,7 +11,7 @@ import (
 func getIgnoredFolders() map[string]struct{} {
 	usr, err := user.Current()
 	if err != nil {
-		fmt.Println("Wasn't able to retrieve current user at runtime")
+		log.Println("Wasn't able to retrieve current user at runtime")
 		return map[string]struct{}{}
 	}
 	ignoreFileName := filepath.Join(usr.HomeDir, ".goduignore")
@@ -20,7 +20,7 @@ func getIgnoredFolders() map[string]struct{} {
 	}
 	ignoreFile, err := os.Open(ignoreFileName)
 	if err != nil {
-		fmt.Printf("Failed to read ingorefile because %s\n", err.Error())
+		log.Printf("Failed to read ingorefile because %s\n", err.Error())
 		return map[string]struct{}{}
 	}
 	defer ignoreFile.Close()

--- a/interactive/printer.go
+++ b/interactive/printer.go
@@ -1,0 +1,43 @@
+package interactive
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/viktomas/godu/core"
+)
+
+func PrintMarkedFiles(state *core.State, writer io.Writer) {
+	markedFolders := make(map[string]*core.File)
+	for file := range state.MarkedFiles {
+		if file.IsDir {
+			dirName := file.Path()
+			// Mark folder with a slash after its name
+			if _, found := markedFolders[dirName+"/"]; !found {
+				markedFolders[dirName+"/"] = file
+			}
+		}
+	}
+markCheck:
+	for file := range state.MarkedFiles {
+		if file.Parent == nil {
+			// This should never happen, just to make sure that we never nil-dereference
+			continue
+		}
+		dirName := file.Parent.Name
+		if dirName == "." {
+			// Do not ignore folders in root dir
+			dirName = file.Name
+		} else {
+			for folderName, folder := range markedFolders {
+				// Check if the file is in any of the marked folders
+				if strings.HasPrefix(dirName+"/", folderName) && file != folder {
+					// If so, break
+					continue markCheck
+				}
+			}
+		}
+		fmt.Fprintf(writer, "'%s'\n", file.Path())
+	}
+}

--- a/interactive/printer_test.go
+++ b/interactive/printer_test.go
@@ -1,0 +1,67 @@
+package interactive
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/viktomas/godu/core"
+)
+
+func TestPrintMarkedFilesNone(t *testing.T) {
+	marked := make(map[*core.File]struct{})
+	state := &core.State{MarkedFiles: marked}
+	var buffer bytes.Buffer
+	writer := bufio.NewWriter(&buffer)
+	defer writer.Flush()
+	PrintMarkedFiles(state, writer)
+	result := buffer.String()
+	if result != "" {
+		t.Errorf("Expected empty output from PrintMarkedFiles, got '%s'", result)
+	}
+}
+
+func TestPrintMarkedFiles(t *testing.T) {
+	marked := make(map[*core.File]struct{})
+	root := &core.File{Name: "."}
+	f1 := &core.File{Name: "f1"}
+	f2 := &core.File{Name: "f2"}
+	f3 := &core.File{Name: "f3", Parent: nil}
+	d1 := &core.File{Name: "d1", IsDir: true, Parent: root, Files: []*core.File{f1}}
+	d2 := &core.File{Name: "d2", IsDir: true, Parent: root}
+	d3 := &core.File{Name: "d3", IsDir: true, Parent: d1, Files: []*core.File{f2}}
+	f1.Parent = d1
+	f2.Parent = d3
+	marked[d1] = struct{}{}
+	marked[d2] = struct{}{}
+	marked[f1] = struct{}{}
+	marked[f2] = struct{}{}
+	marked[f3] = struct{}{}
+	state := &core.State{MarkedFiles: marked}
+	var buffer bytes.Buffer
+	writer := bufio.NewWriter(&buffer)
+	PrintMarkedFiles(state, writer)
+	writer.Flush()
+	result := buffer.String()
+	// We don't know the order, as we are using a map to store marked files :/
+	expected := `'d1'
+'d2'
+'d1/d3/f2'`
+	if hasSameLines(result, expected) {
+		t.Errorf("Expected '%s' from PrintMarkedFiles, got '%s'", expected, result)
+	}
+}
+
+func hasSameLines(s1, s2 string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	ss1 := strings.Split(s1, "\n")
+	for _, l1 := range ss1 {
+		if !strings.Contains(s2, l1+"\n") {
+			return false
+		}
+	}
+	return true
+}

--- a/interactive/reporter.go
+++ b/interactive/reporter.go
@@ -2,17 +2,31 @@ package interactive
 
 import (
 	"fmt"
+
 	"github.com/viktomas/godu/core"
 )
 
-func ReportTree(folder *core.File) []string {
-	report := make([]string, len(folder.Files))
+type Line struct {
+	Text     []rune
+	IsMarked bool
+}
+
+func ReportTree(folder *core.File, markedFiles map[*core.File]struct{}) []Line {
+	report := make([]Line, len(folder.Files))
 	for index, file := range folder.Files {
 		name := file.Name
 		if file.IsDir {
 			name = name + "/"
 		}
-		report[index] = fmt.Sprintf("%s %s", formatBytes(file.Size), name)
+		var marking string
+		_, isMarked := markedFiles[file]
+		if isMarked {
+			marking = "*"
+		}
+		report[index] = Line{
+			Text:     []rune(fmt.Sprintf("%s%s %s", marking, formatBytes(file.Size), name)),
+			IsMarked: isMarked,
+		}
 	}
 	return report
 }

--- a/interactive/reporter_test.go
+++ b/interactive/reporter_test.go
@@ -8,63 +8,73 @@ import (
 )
 
 func TestReportTree(t *testing.T) {
-	testTree := &core.File{"b", 180, true, []*core.File{
-		&core.File{"c", 100, false, []*core.File{}},
-		&core.File{"d", 80, true, []*core.File{
-			&core.File{"e", 50, false, []*core.File{}},
-			&core.File{"f", 30, false, []*core.File{}},
+	marked := make(map[*core.File]struct{})
+	testTree := &core.File{"b", nil, 180, true, []*core.File{
+		&core.File{"c", nil, 100, false, []*core.File{}},
+		&core.File{"d", nil, 80, true, []*core.File{
+			&core.File{"e", nil, 50, false, []*core.File{}},
+			&core.File{"f", nil, 30, false, []*core.File{}},
 		}},
 	}}
-	expected := []string{" 100B c", "  80B d/"}
-	testTreeAgainstOutput(testTree, expected, t)
+	marked[testTree.Files[0]] = struct{}{}
+	expected := []Line{
+		Line{Text: []rune("* 100B c"), IsMarked: true},
+		Line{Text: []rune("  80B d/")},
+	}
+	testTreeAgainstOutput(testTree, marked, expected, t)
 }
 
 func TestPrintsEmptyDir(t *testing.T) {
-	testTree := &core.File{"", 50, true, []*core.File{
-		&core.File{"a", 50, true, []*core.File{}},
+	marked := make(map[*core.File]struct{})
+	testTree := &core.File{"", nil, 50, true, []*core.File{
+		&core.File{"a", nil, 50, true, []*core.File{}},
 	}}
-	expected := []string{"  50B a/"}
-	testTreeAgainstOutput(testTree, expected, t)
+	expected := []Line{
+		Line{Text: []rune("  50B a/")},
+	}
+	testTreeAgainstOutput(testTree, marked, expected, t)
 }
 
 func TestFiveCharSize(t *testing.T) {
-	testTree := &core.File{"X", 0, true, []*core.File{
-		&core.File{"o", 1, false, []*core.File{}},
-		&core.File{"on", 10, false, []*core.File{}},
-		&core.File{"one", 100, false, []*core.File{}},
-		&core.File{"one1", 1000, false, []*core.File{}},
+	marked := make(map[*core.File]struct{})
+	testTree := &core.File{"X", nil, 0, true, []*core.File{
+		&core.File{"o", nil, 1, false, []*core.File{}},
+		&core.File{"on", nil, 10, false, []*core.File{}},
+		&core.File{"one", nil, 100, false, []*core.File{}},
+		&core.File{"one1", nil, 1000, false, []*core.File{}},
 	}}
-	ex := []string{
-		"   1B o",
-		"  10B on",
-		" 100B one",
-		"1000B one1",
+	ex := []Line{
+		Line{Text: []rune("   1B o")},
+		Line{Text: []rune("  10B on")},
+		Line{Text: []rune(" 100B one")},
+		Line{Text: []rune("1000B one1")},
 	}
-	testTreeAgainstOutput(testTree, ex, t)
+	testTreeAgainstOutput(testTree, marked, ex, t)
 }
 
 func TestReportingUnits(t *testing.T) {
-	testTree := &core.File{"X", 0, true, []*core.File{
-		&core.File{"B", 1 << 0, false, []*core.File{}},
-		&core.File{"K", 1 << 10, false, []*core.File{}},
-		&core.File{"M", 1048576, false, []*core.File{}},
-		&core.File{"G", 1073741824, false, []*core.File{}},
-		&core.File{"T", 1099511627776, false, []*core.File{}},
-		&core.File{"P", 1125899906842624, false, []*core.File{}},
+	marked := make(map[*core.File]struct{})
+	testTree := &core.File{"X", nil, 0, true, []*core.File{
+		&core.File{"B", nil, 1 << 0, false, []*core.File{}},
+		&core.File{"K", nil, 1 << 10, false, []*core.File{}},
+		&core.File{"M", nil, 1048576, false, []*core.File{}},
+		&core.File{"G", nil, 1073741824, false, []*core.File{}},
+		&core.File{"T", nil, 1099511627776, false, []*core.File{}},
+		&core.File{"P", nil, 1125899906842624, false, []*core.File{}},
 	}}
-	ex := []string{
-		"   1B B",
-		"   1K K",
-		"   1M M",
-		"   1G G",
-		"   1T T",
-		"   1P P",
+	ex := []Line{
+		Line{Text: []rune("   1B B")},
+		Line{Text: []rune("   1K K")},
+		Line{Text: []rune("   1M M")},
+		Line{Text: []rune("   1G G")},
+		Line{Text: []rune("   1T T")},
+		Line{Text: []rune("   1P P")},
 	}
-	testTreeAgainstOutput(testTree, ex, t)
+	testTreeAgainstOutput(testTree, marked, ex, t)
 }
 
-func testTreeAgainstOutput(testTree *core.File, expected []string, t *testing.T) {
-	result := ReportTree(testTree)
+func testTreeAgainstOutput(testTree *core.File, marked map[*core.File]struct{}, expected []Line, t *testing.T) {
+	result := ReportTree(testTree, marked)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("expected:\n%sbut got:\n%s", expected, result)
 	}

--- a/parser.go
+++ b/parser.go
@@ -27,6 +27,12 @@ func ParseCommand(s tcell.Screen, commands chan core.Executer, wg *sync.WaitGrou
 				commands <- core.GoBack{}
 			case tcell.KeyCtrlL:
 				s.Sync()
+			case tcell.KeyRune:
+				switch ev.Rune() {
+				case ' ':
+					commands <- core.Mark{}
+				}
+
 			}
 		case *tcell.EventResize:
 			s.Sync()

--- a/state_model.go
+++ b/state_model.go
@@ -7,24 +7,22 @@ import (
 )
 
 type VisualState struct {
-	folders        [][]rune
+	folders        []interactive.Line
 	selected       int
 	xbound, ybound int
 }
 
 func NewVisualState(state core.State) VisualState {
-	lines := interactive.ReportTree(state.Folder)
-	folders := make([][]rune, len(lines))
+	lines := interactive.ReportTree(state.Folder, state.MarkedFiles)
 	xbound := 0
-	ybound := len(folders)
+	ybound := len(lines)
 	for index, line := range lines {
-		runeLine := []rune(line)
-		if len(runeLine)-1 > xbound {
-			xbound = len(runeLine) - 1
+		if len(line.Text)-1 > xbound {
+			xbound = len(line.Text) - 1
 		}
-		folders[index] = runeLine
+		lines[index] = line
 	}
-	return VisualState{folders, state.Selected, xbound, ybound}
+	return VisualState{lines, state.Selected, xbound, ybound}
 }
 
 func (vs VisualState) GetCell(x, y int) (rune, tcell.Style, []rune, int) {
@@ -32,8 +30,14 @@ func (vs VisualState) GetCell(x, y int) (rune, tcell.Style, []rune, int) {
 	if y == vs.selected {
 		style = style.Reverse(true)
 	}
-	if y < len(vs.folders) && x < len(vs.folders[y]) {
-		return vs.folders[y][x], style, nil, 1
+	if y < len(vs.folders) {
+		line := vs.folders[y]
+		if line.IsMarked {
+			style = style.Foreground(tcell.ColorGreen)
+		}
+		if x < len(vs.folders[y].Text) {
+			return line.Text[x], style, nil, 1
+		}
 	}
 	return ' ', style, nil, 1
 }


### PR DESCRIPTION
This adds support to mark files & folders via the space key.
This is useful if you want to use `godu` to remove large files:

```sh
$ godu . | xargs rm
```