### PR TITLE
Fixing bug when godu fails with folder without bug files

### DIFF
--- a/core/file_walker.go
+++ b/core/file_walker.go
@@ -15,12 +15,12 @@ type File struct {
 
 type ReadDir func(dirname string) ([]os.FileInfo, error)
 
-func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}) File {
+func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}) *File {
 	_, name := filepath.Split(path)
 	entries, err := readDir(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "godu: %v\n", err)
-		return File{}
+		return &File{}
 	}
 	files := make([]*File, 0, len(entries))
 	var folderSize int64
@@ -33,7 +33,7 @@ func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}
 			subDir := filepath.Join(path, entry.Name())
 			subfolder := GetSubTree(subDir, readDir, ignoredFolders)
 			folderSize += subfolder.Size
-			files = append(files, &subfolder)
+			files = append(files, subfolder)
 		} else {
 			size := entry.Size()
 			folderSize += size
@@ -46,5 +46,5 @@ func GetSubTree(path string, readDir ReadDir, ignoredFolders map[string]struct{}
 			files = append(files, file)
 		}
 	}
-	return File{name, folderSize, true, files}
+	return &File{name, folderSize, true, files}
 }

--- a/core/file_walker_test.go
+++ b/core/file_walker_test.go
@@ -73,7 +73,7 @@ func TestGetSubTreeOnSimpleDir(t *testing.T) {
 			&File{"f", 30, false, []*File{}},
 		}},
 	}}
-	if !reflect.DeepEqual(result, expected) {
+	if !reflect.DeepEqual(*result, expected) {
 		t.Error("file tree wasn't walked correctly")
 		fmt.Printf("expected: %v", expected)
 		fmt.Printf("result: %v", result)
@@ -86,7 +86,7 @@ func TestGetSubTreeHandlesError(t *testing.T) {
 		return []os.FileInfo{}, errors.New("Not found")
 	}
 	result := GetSubTree("xyz", failing, map[string]struct{}{})
-	if !reflect.DeepEqual(result, File{}) {
+	if !reflect.DeepEqual(*result, File{}) {
 		t.Error("GetSubTree didn't return emtpy file on ReadDir failure")
 	}
 }

--- a/core/processor.go
+++ b/core/processor.go
@@ -1,17 +1,26 @@
 package core
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
+
+func PrepareTree(tree *File, limit int64) error {
+	PruneTree(tree, limit)
+	if len(tree.Files) == 0 {
+		return fmt.Errorf("the folder '%s' doesn't contain any files bigger than %dMB", tree.Name, limit/MEGABYTE)
+	}
+	SortDesc(tree)
+	return nil
+}
 
 func StartProcessing(
 	folder *File,
-	limit int64,
 	commands chan Executer,
 	states chan State,
 	wg *sync.WaitGroup,
 ) {
 	defer wg.Done()
-	PruneTree(folder, limit)
-	SortDesc(folder)
 	state := State{
 		Folder: folder,
 	}

--- a/godu.go
+++ b/godu.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"sync"
 
@@ -19,14 +19,19 @@ func main() {
 	if len(args) > 0 {
 		root = args[0]
 	}
-	fmt.Printf("godu will walk through `%s` that might take up to few minutes\n", root)
+	log.Printf("godu will walk through `%s` that might take up to few minutes\n", root)
 	tree := core.GetSubTree(root, ioutil.ReadDir, getIgnoredFolders())
+	err := core.PrepareTree(tree, *limit*core.MEGABYTE)
+	if err != nil {
+		log.Println(err.Error())
+		os.Exit(0)
+	}
 	s := initScreen()
 	commands := make(chan core.Executer)
 	states := make(chan core.State)
 	var wg sync.WaitGroup
 	wg.Add(3)
-	go core.StartProcessing(&tree, *limit*core.MEGABYTE, commands, states, &wg)
+	go core.StartProcessing(tree, commands, states, &wg)
 	go InteractiveTree(s, states, &wg)
 	go ParseCommand(s, commands, &wg)
 	wg.Wait()
@@ -37,11 +42,11 @@ func initScreen() tcell.Screen {
 	tcell.SetEncodingFallback(tcell.EncodingFallbackASCII)
 	s, e := tcell.NewScreen()
 	if e != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", e)
+		log.Printf("%v\n", e)
 		os.Exit(1)
 	}
 	if e = s.Init(); e != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", e)
+		log.Printf("%v\n", e)
 		os.Exit(1)
 	}
 	s.Clear()


### PR DESCRIPTION
- We were trying to access Files[0] on empty folder
- After pruning we need to check if there any files left

- using log instead of fmt

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

fixes #16

