### PR TITLE
Since we introduced bi-directional tree we don't need ancestors in state

### DIFF
--- a/core/command.go
+++ b/core/command.go
@@ -4,7 +4,6 @@ import "errors"
 
 // State represents system configuration after processing user input
 type State struct {
-	ancestors   ancestors
 	Folder      *File
 	Selected    int
 	history     map[*File]int // history of all selected postions
@@ -34,18 +33,8 @@ type Up struct{}
 
 type Mark struct{}
 
-func (s State) Path() string {
-	var path string
-	for _, ancestor := range s.ancestors {
-		path = path + ancestor.Name + "/"
-	}
-	path = path + s.Folder.Name + "/"
-	return path
-}
-
 func copyState(state State) State {
 	return State{
-		ancestors:   state.ancestors,
 		Folder:      state.Folder,
 		history:     state.history,
 		Selected:    state.Selected,
@@ -82,7 +71,6 @@ func (e Enter) Execute(oldState State) (State, error) {
 	}
 	newHistory[oldState.Folder] = oldState.Selected
 	return State{
-		ancestors:   oldState.ancestors.push(oldState.Folder),
 		Folder:      newFolder,
 		history:     newHistory,
 		Selected:    newHistory[newFolder],
@@ -91,7 +79,7 @@ func (e Enter) Execute(oldState State) (State, error) {
 }
 
 func (GoBack) Execute(oldState State) (State, error) {
-	parentFolder, newAncestors := oldState.ancestors.pop()
+	parentFolder := oldState.Folder.Parent
 	if parentFolder == nil {
 		return oldState, errors.New("Trying to go back on root")
 	}
@@ -101,7 +89,6 @@ func (GoBack) Execute(oldState State) (State, error) {
 	}
 	newHistory[oldState.Folder] = oldState.Selected
 	return State{
-		ancestors:   newAncestors,
 		Folder:      parentFolder,
 		history:     newHistory,
 		Selected:    newHistory[parentFolder],

--- a/core/command_test.go
+++ b/core/command_test.go
@@ -5,19 +5,6 @@ import (
 	"testing"
 )
 
-func TestStatePath(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFolder("c", NewTestFile("d", 50)))
-	subTree := tree.Files[1]
-	initialState := State{
-		ancestors: ancestors{tree},
-		Folder:    subTree,
-	}
-	expected := "a/c/"
-	if initialState.Path() != expected {
-		t.Errorf("expected path %s, but got %s", expected, initialState.Path())
-	}
-}
-
 func TestDownCommand(t *testing.T) {
 	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
 	initialState := State{
@@ -88,7 +75,6 @@ func TestEnterCommand(t *testing.T) {
 	command := Enter{}
 	newState, _ := command.Execute(initialState)
 	expectedState := State{
-		ancestors:   ancestors{tree},
 		Folder:      subTree,
 		history:     map[*File]int{tree: 1, subTree: 1},
 		Selected:    1,
@@ -117,7 +103,6 @@ func TestGoBackCommand(t *testing.T) {
 	subTree := tree.Files[1]
 	marked := make(map[*File]struct{})
 	initialState := State{
-		ancestors:   ancestors{tree},
 		Folder:      subTree,
 		history:     map[*File]int{tree: 1},
 		Selected:    1,
@@ -126,7 +111,6 @@ func TestGoBackCommand(t *testing.T) {
 	command := GoBack{}
 	newState, _ := command.Execute(initialState)
 	expectedState := State{
-		ancestors:   ancestors{},
 		Folder:      tree,
 		history:     map[*File]int{tree: 1, subTree: 1},
 		Selected:    1,
@@ -140,8 +124,7 @@ func TestGoBackCommand(t *testing.T) {
 func TestGoBackOnRoot(t *testing.T) {
 	tree := NewTestFolder("a", NewTestFile("b", 50))
 	initialState := State{
-		ancestors: ancestors{},
-		Folder:    tree,
+		Folder: tree,
 	}
 	command := GoBack{}
 	_, err := command.Execute(initialState)
@@ -153,7 +136,6 @@ func TestGoBackOnRoot(t *testing.T) {
 func TestMarkFile(t *testing.T) {
 	tree := NewTestFolder("a", NewTestFile("b", 50))
 	initialState := State{
-		ancestors:   ancestors{},
 		Folder:      tree,
 		Selected:    0,
 		MarkedFiles: make(map[*File]struct{}),


### PR DESCRIPTION
- simplifies the code a lot
- this refactoring was necessary after introducing marking files
- @leonklingele I'm glad that you introduced the `File.Parent` it simplified this a lot.

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

