### PR TITLE
Changes to the concurrent GetSubTree

### DIFF
--- a/core/file_walker_test.go
+++ b/core/file_walker_test.go
@@ -78,7 +78,7 @@ func TestGetSubTreeOnSimpleDir(t *testing.T) {
 		}},
 	}}
 	ignoredFolders := map[string]struct{}{"g": struct{}{}}
-	result := GetSubTree("b", nil, createReadDir(testStructure), ignoredFolders)
+	result := WalkFolder("b", createReadDir(testStructure), ignoredFolders)
 	buildExpected := func() *File {
 		b := &File{"b", nil, 180, true, []*File{}}
 		c := &File{"c", b, 100, false, []*File{}}
@@ -105,7 +105,7 @@ func TestGetSubTreeHandlesError(t *testing.T) {
 	failing := func(path string) ([]os.FileInfo, error) {
 		return []os.FileInfo{}, errors.New("Not found")
 	}
-	result := GetSubTree("xyz", nil, failing, map[string]struct{}{})
+	result := WalkFolder("xyz", failing, map[string]struct{}{})
 	if !reflect.DeepEqual(*result, File{}) {
 		t.Error("GetSubTree didn't return emtpy file on ReadDir failure")
 	}

--- a/godu.go
+++ b/godu.go
@@ -22,7 +22,7 @@ func main() {
 		root = args[0]
 	}
 	log.Printf("godu will walk through `%s` that might take up to few minutes\n", root)
-	tree := core.GetSubTree(root, nil, ioutil.ReadDir, getIgnoredFolders())
+	tree := core.WalkFolder(root, ioutil.ReadDir, getIgnoredFolders())
 	err := core.PrepareTree(tree, *limit*core.MEGABYTE)
 	if err != nil {
 		log.Println(err.Error())


### PR DESCRIPTION
- removing parent argument that was always nil
- seting maxConcurrentScans to number of CPUs
- mutex only on one folder

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

- yesterday at midnight I didn't put enough effort into you pull request review @leonklingele. These are my suggestions, I'm happy to push only subset of them if you don't agree with some of them.

- Next time I'll probably wait with PR review till morning

