### PR TITLE
Quick fix that makes root folder contain its absolute path as a name.

### DIFF
--- a/godu.go
+++ b/godu.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/gdamore/tcell"
@@ -21,9 +22,15 @@ func main() {
 	if len(args) > 0 {
 		root = args[0]
 	}
+	root, err := filepath.Abs(root)
+	if err != nil {
+		log.Println(err.Error())
+		os.Exit(0)
+	}
 	log.Printf("godu will walk through `%s` that might take up to few minutes\n", root)
 	tree := core.WalkFolder(root, ioutil.ReadDir, getIgnoredFolders())
-	err := core.PrepareTree(tree, *limit*core.MEGABYTE)
+	tree.Name = root
+	err = core.PrepareTree(tree, *limit*core.MEGABYTE)
 	if err != nil {
 		log.Println(err.Error())
 		os.Exit(0)


### PR DESCRIPTION
- bit hacky, I know

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

