### PR TITLE
interactive/reporter: Fix type format identifier in test

### DIFF
--- a/interactive/reporter_test.go
+++ b/interactive/reporter_test.go
@@ -74,6 +74,6 @@ func TestReportingUnits(t *testing.T) {
 func testTreeAgainstOutput(testTree *core.File, marked map[*core.File]struct{}, expected []Line, t *testing.T) {
 	result := ReportTree(testTree, marked)
 	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("expected:\n%sbut got:\n%s", expected, result)
+		t.Errorf("expected:\n%vbut got:\n%v", expected, result)
 	}
 }


### PR DESCRIPTION
The test was failing with the following error:
"Errorf format %s has arg expected of wrong type []interactive.Line"

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

