### PR TITLE
Add support for '--noquote' flag which doesn't quote file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The `.goduignore` is currently only supporting whole folder names. PR that will 
 ```
 godu ~
 godu -l 100 / # walks the whole root but shows only files larger than 100MB
-# godu -print0 ~ | xargs -0 rm # use with caution! Will delete all marked files!
+# godu -noquote -print0 ~ | xargs -0 rm # use with caution! Will delete all marked files!
 ```
 
 The currently selected file / folder can be un/marked with the space-key. Upon exiting, godu prinsts all marked files & folders to stdout so they can be further processed (e.g. via the `xargs` command).

--- a/godu.go
+++ b/godu.go
@@ -16,6 +16,7 @@ import (
 
 func main() {
 	limit := flag.Int64("l", 10, "show only files larger than limit (in MB)")
+	noquote := flag.Bool("noquote", false, "do not quote file paths")
 	nullTerminate := flag.Bool("print0", false, "print null-terminated strings")
 	flag.Parse()
 	args := flag.Args()
@@ -46,11 +47,11 @@ func main() {
 	wg.Wait()
 	s.Fini()
 	lastState := <-lastStateChan
-	printMarkedFiles(lastState, *nullTerminate)
+	printMarkedFiles(lastState, !*noquote, *nullTerminate)
 }
 
-func printMarkedFiles(lastState *core.State, nullTerminate bool) {
-	markedFiles := interactive.QuoteMarkedFiles(lastState.MarkedFiles)
+func printMarkedFiles(lastState *core.State, quote, nullTerminate bool) {
+	markedFiles := interactive.FilesAsSlice(lastState.MarkedFiles, quote)
 	var printFunc func(string)
 	if nullTerminate {
 		printFunc = func(s string) {

--- a/interactive/printer.go
+++ b/interactive/printer.go
@@ -14,20 +14,23 @@ func (l byLength) Len() int           { return len(l) }
 func (l byLength) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
 func (l byLength) Less(i, j int) bool { return len(l[i]) > len(l[j]) }
 
-// QuoteMarkedFiles takes files from the map and returns slice of qoted file paths
-func QuoteMarkedFiles(markedFiles map[*core.File]struct{}) []string {
-	quotedFiles := make([]string, len(markedFiles))
-	i := 0
-	for file := range markedFiles {
+// FilesAsSlice takes files from the map and returns a sorted slice of file paths.
+// Each file path is quoted if 'quote' is set to true.
+func FilesAsSlice(in map[*core.File]struct{}, quote bool) []string {
+	out := make([]string, 0, len(in))
+	for file := range in {
 		p := file.Path()
-		// Escape single quotes
-		p = strings.Replace(p, "'", "\\'", -1)
-		quotedFiles[i] = fmt.Sprintf("'%s'", p)
-		i++
+		if quote {
+			// Escape single quotes
+			p = strings.Replace(p, "'", "\\'", -1)
+			// Quote full file path
+			p = fmt.Sprintf("'%s'", p)
+		}
+		out = append(out, p)
 	}
 	// sorting lenght of the path (assuming that we want to deleate files in subdirs first)
 	// alphabetical sorting added for determinism (map keys doesn't guarantee order)
-	sort.Sort(sort.StringSlice(quotedFiles))
-	sort.Sort(byLength(quotedFiles))
-	return quotedFiles
+	sort.Sort(sort.StringSlice(out))
+	sort.Sort(byLength(out))
+	return out
 }

--- a/interactive/printer_test.go
+++ b/interactive/printer_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/viktomas/godu/core"
 )
 
-func TestPrintEmptyMarkedFiles(t *testing.T) {
+func TestFilesAsSliceEmptyMap(t *testing.T) {
 	marked := make(map[*core.File]struct{})
-	result := QuoteMarkedFiles(marked)
+	result := FilesAsSlice(marked, false)
 	if len(result) > 0 {
-		t.Errorf("Expected empty output from PrintMarkedFiles, got '%v'", result)
+		t.Errorf("Expected empty output, got '%v'", result)
 	}
 }
 
-func TestPrintMarkedFiles(t *testing.T) {
+func TestFilesAsSlice(t *testing.T) {
 	root := core.NewTestFolder(".",
 		core.NewTestFile("'single''quotes'", 0),
 		core.NewTestFolder("d1",
@@ -33,9 +33,23 @@ func TestPrintMarkedFiles(t *testing.T) {
 	marked[core.FindTestFile(root, "f1")] = struct{}{}
 	marked[core.FindTestFile(root, "f2")] = struct{}{}
 	marked[core.FindTestFile(root, "'single''quotes'")] = struct{}{}
-	result := QuoteMarkedFiles(marked)
-	expected := []string{"'\\'single\\'\\'quotes\\''", "'d1/d3/f2'", "'d1/f1'", "'d1'", "'d2'"}
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected '%v' from PrintMarkedFiles, got '%v'", expected, result)
+
+	evalFunc := func(want, got []string, t *testing.T) {
+		// t.Helper() // TODO: Requires Go 1.9
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("Expected '%v', got '%v'", want, got)
+		}
 	}
+
+	t.Run("unquoted", func(t *testing.T) {
+		want := []string{"'single''quotes'", "d1/d3/f2", "d1/f1", "d1", "d2"}
+		got := FilesAsSlice(marked, false)
+		evalFunc(want, got, t)
+	})
+
+	t.Run("quoted", func(t *testing.T) {
+		want := []string{"'\\'single\\'\\'quotes\\''", "'d1/d3/f2'", "'d1/f1'", "'d1'", "'d2'"}
+		got := FilesAsSlice(marked, true)
+		evalFunc(want, got, t)
+	})
 }


### PR DESCRIPTION
This fixes an issue introduced in 846a402 where null-terminated
file paths (using "--print0") were not properly passed from "xargs"
to its specified utility function.
When "xargs" is used with "-0" (expecting null-terminated strings)
which then passes its output to e.g. "ls", the command interprets
the surrounding single quotes as part of the file name and fails.

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

