### PR TITLE
Remove support for quoting file paths

### DIFF
--- a/godu.go
+++ b/godu.go
@@ -50,7 +50,7 @@ func main() {
 }
 
 func printMarkedFiles(lastState *core.State, nullTerminate bool) {
-	markedFiles := interactive.QuoteMarkedFiles(lastState.MarkedFiles)
+	markedFiles := interactive.FilesAsSlice(lastState.MarkedFiles)
 	var printFunc func(string)
 	if nullTerminate {
 		printFunc = func(s string) {
@@ -61,8 +61,8 @@ func printMarkedFiles(lastState *core.State, nullTerminate bool) {
 			fmt.Println(s)
 		}
 	}
-	for _, quotedFile := range markedFiles {
-		printFunc(quotedFile)
+	for _, f := range markedFiles {
+		printFunc(f)
 	}
 }
 

--- a/interactive/printer.go
+++ b/interactive/printer.go
@@ -1,9 +1,7 @@
 package interactive
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/viktomas/godu/core"
 )
@@ -14,20 +12,16 @@ func (l byLength) Len() int           { return len(l) }
 func (l byLength) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
 func (l byLength) Less(i, j int) bool { return len(l[i]) > len(l[j]) }
 
-// QuoteMarkedFiles takes files from the map and returns slice of qoted file paths
-func QuoteMarkedFiles(markedFiles map[*core.File]struct{}) []string {
-	quotedFiles := make([]string, len(markedFiles))
-	i := 0
-	for file := range markedFiles {
+// FilesAsSlice takes files from the map and returns a sorted slice of file paths.
+func FilesAsSlice(in map[*core.File]struct{}) []string {
+	out := make([]string, 0, len(in))
+	for file := range in {
 		p := file.Path()
-		// Escape single quotes
-		p = strings.Replace(p, "'", "\\'", -1)
-		quotedFiles[i] = fmt.Sprintf("'%s'", p)
-		i++
+		out = append(out, p)
 	}
 	// sorting lenght of the path (assuming that we want to deleate files in subdirs first)
 	// alphabetical sorting added for determinism (map keys doesn't guarantee order)
-	sort.Sort(sort.StringSlice(quotedFiles))
-	sort.Sort(byLength(quotedFiles))
-	return quotedFiles
+	sort.Sort(sort.StringSlice(out))
+	sort.Sort(byLength(out))
+	return out
 }

--- a/interactive/printer_test.go
+++ b/interactive/printer_test.go
@@ -7,15 +7,15 @@ import (
 	"github.com/viktomas/godu/core"
 )
 
-func TestPrintEmptyMarkedFiles(t *testing.T) {
+func TestFilesAsSliceEmptyMap(t *testing.T) {
 	marked := make(map[*core.File]struct{})
-	result := QuoteMarkedFiles(marked)
+	result := FilesAsSlice(marked)
 	if len(result) > 0 {
-		t.Errorf("Expected empty output from PrintMarkedFiles, got '%v'", result)
+		t.Errorf("Expected empty output, got '%v'", result)
 	}
 }
 
-func TestPrintMarkedFiles(t *testing.T) {
+func TestFilesAsSlice(t *testing.T) {
 	root := core.NewTestFolder(".",
 		core.NewTestFile("'single''quotes'", 0),
 		core.NewTestFolder("d1",
@@ -33,9 +33,10 @@ func TestPrintMarkedFiles(t *testing.T) {
 	marked[core.FindTestFile(root, "f1")] = struct{}{}
 	marked[core.FindTestFile(root, "f2")] = struct{}{}
 	marked[core.FindTestFile(root, "'single''quotes'")] = struct{}{}
-	result := QuoteMarkedFiles(marked)
-	expected := []string{"'\\'single\\'\\'quotes\\''", "'d1/d3/f2'", "'d1/f1'", "'d1'", "'d2'"}
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("Expected '%v' from PrintMarkedFiles, got '%v'", expected, result)
+
+	want := []string{"'single''quotes'", "d1/d3/f2", "d1/f1", "d1", "d2"}
+	got := FilesAsSlice(marked)
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("Expected '%v', got '%v'", want, got)
 	}
 }


### PR DESCRIPTION
This fixes an issue introduced in 846a402 where null-terminated
file paths (using "--print0") were not properly passed from "xargs"
to its specified utility function.
When "xargs" is used with "-0" (expecting null-terminated strings)
which then passes its output to e.g. "ls", the command interprets
the surrounding single quotes as part of the file name and fails.
Instead of adding another flag to explicitly disable file-path
quoting, remove support for it altogether as discussed in #51.

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

