### PR TITLE
Rename tree to folder + updated documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,14 @@ Main things to consider when implementing new functionality is packages, there a
 - Please make sure that you are never using pointers(and arrays) from `oldState` when creating `newState` in a `Executer` (a.k.a. command)
 
 ### the root folder structure should only represent the file system
-You would notice that in `main.go` we are walking through the whole folder using
+You would notice that in `godu.go` we are walking through the whole folder using
 ```
-tree := core.GetSubTree(root, ioutil.ReadDir, getIgnoredFolders())
+rootFolder := core.WalkFolder(rootFolderName, ioutil.ReadDir, getIgnoredFolders())
 ```
-The expectation is that the `core.File` structure contains only representation of the file system and it is not going to change after calling `GetSubTree`
+The expectation is that the `core.File` structure contains only representation of the file system and it is not going to change after calling `WalkFolder`
 
 ### Everything that commands do should be represented in State
-When implementing new command please make sure that it's result is captured in a state and that the state is appropriately displayed using `InteractiveTree` (e.g. highlighting selected line in file column)
+When implementing new command please make sure that it's result is captured in a state and that the state is appropriately displayed using `InteractiveFolder` (e.g. highlighting selected line in file column)
 
 ## 100% test coverage
 Expectation is that `core` and `interactive` packages will have 100% test coverage. I'm not a testing nazi but I won't have time to checkout every PR and manually retest it and neither will you. We need to be confident that `godu` still works after merging your (and any subsequent) PR.

--- a/core/command_test.go
+++ b/core/command_test.go
@@ -6,9 +6,9 @@ import (
 )
 
 func TestDownCommand(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
 	initialState := State{
-		Folder: tree,
+		Folder: folder,
 	}
 	newState, _ := Down{}.Execute(initialState)
 	if newState.Selected != 1 {
@@ -18,9 +18,9 @@ func TestDownCommand(t *testing.T) {
 }
 
 func TestDownCommandFails(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
 	initialState := State{
-		Folder:   tree,
+		Folder:   folder,
 		Selected: 1,
 	}
 	newState, err := Down{}.Execute(initialState)
@@ -34,9 +34,9 @@ func TestDownCommandFails(t *testing.T) {
 }
 
 func TestUpCommand(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
 	initialState := State{
-		Folder:   tree,
+		Folder:   folder,
 		Selected: 1,
 	}
 	newState, _ := Up{}.Execute(initialState)
@@ -47,9 +47,9 @@ func TestUpCommand(t *testing.T) {
 }
 
 func TestUpCommandFails(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50), NewTestFile("c", 50))
 	initialState := State{
-		Folder:   tree,
+		Folder:   folder,
 		Selected: 0,
 	}
 	newState, err := Up{}.Execute(initialState)
@@ -63,20 +63,20 @@ func TestUpCommandFails(t *testing.T) {
 }
 
 func TestEnterCommand(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFolder("c", NewTestFile("d", 50), NewTestFile("e", 50)))
-	subTree := tree.Files[1]
+	folder := NewTestFolder("a", NewTestFile("b", 50), NewTestFolder("c", NewTestFile("d", 50), NewTestFile("e", 50)))
+	subFolder := folder.Files[1]
 	marked := make(map[*File]struct{})
 	initialState := State{
-		Folder:      tree,
-		history:     map[*File]int{subTree: 1},
+		Folder:      folder,
+		history:     map[*File]int{subFolder: 1},
 		Selected:    1,
 		MarkedFiles: marked,
 	}
 	command := Enter{}
 	newState, _ := command.Execute(initialState)
 	expectedState := State{
-		Folder:      subTree,
-		history:     map[*File]int{tree: 1, subTree: 1},
+		Folder:      subFolder,
+		history:     map[*File]int{folder: 1, subFolder: 1},
 		Selected:    1,
 		MarkedFiles: marked,
 	}
@@ -86,9 +86,9 @@ func TestEnterCommand(t *testing.T) {
 }
 
 func TestEnterCommandFails(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50))
 	initialState := State{
-		Folder: tree,
+		Folder: folder,
 	}
 	command := Enter{}
 	_, err := command.Execute(initialState)
@@ -99,20 +99,20 @@ func TestEnterCommandFails(t *testing.T) {
 }
 
 func TestGoBackCommand(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50), NewTestFolder("c", NewTestFile("d", 50), NewTestFile("e", 50)))
-	subTree := tree.Files[1]
+	folder := NewTestFolder("a", NewTestFile("b", 50), NewTestFolder("c", NewTestFile("d", 50), NewTestFile("e", 50)))
+	subFolder := folder.Files[1]
 	marked := make(map[*File]struct{})
 	initialState := State{
-		Folder:      subTree,
-		history:     map[*File]int{tree: 1},
+		Folder:      subFolder,
+		history:     map[*File]int{folder: 1},
 		Selected:    1,
 		MarkedFiles: marked,
 	}
 	command := GoBack{}
 	newState, _ := command.Execute(initialState)
 	expectedState := State{
-		Folder:      tree,
-		history:     map[*File]int{tree: 1, subTree: 1},
+		Folder:      folder,
+		history:     map[*File]int{folder: 1, subFolder: 1},
 		Selected:    1,
 		MarkedFiles: marked,
 	}
@@ -122,9 +122,9 @@ func TestGoBackCommand(t *testing.T) {
 }
 
 func TestGoBackOnRoot(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50))
 	initialState := State{
-		Folder: tree,
+		Folder: folder,
 	}
 	command := GoBack{}
 	_, err := command.Execute(initialState)
@@ -134,19 +134,19 @@ func TestGoBackOnRoot(t *testing.T) {
 }
 
 func TestMarkFile(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 50))
 	initialState := State{
-		Folder:      tree,
+		Folder:      folder,
 		Selected:    0,
 		MarkedFiles: make(map[*File]struct{}),
 	}
 	command := Mark{}
 	newState, _ := command.Execute(initialState)
-	if _, marked := newState.MarkedFiles[tree.Files[0]]; !marked {
+	if _, marked := newState.MarkedFiles[folder.Files[0]]; !marked {
 		t.Error("File is not marked but should be")
 	}
 	newState, _ = command.Execute(newState)
-	if _, marked := newState.MarkedFiles[tree.Files[0]]; marked {
+	if _, marked := newState.MarkedFiles[folder.Files[0]]; marked {
 		t.Error("File is marked but shouldn't be")
 	}
 }

--- a/core/file_walker_test.go
+++ b/core/file_walker_test.go
@@ -63,7 +63,7 @@ func TestFilePath(t *testing.T) {
 	}
 }
 
-func TestGetSubTreeOnSimpleDir(t *testing.T) {
+func TestWalkFolderOnSimpleDir(t *testing.T) {
 	testStructure := fakeFile{"a", 0, []fakeFile{
 		fakeFile{"b", 0, []fakeFile{
 			fakeFile{"c", 100, []fakeFile{}},
@@ -97,19 +97,19 @@ func TestGetSubTreeOnSimpleDir(t *testing.T) {
 	}
 	expected := buildExpected()
 	if !reflect.DeepEqual(*result, *expected) {
-		t.Error("file tree wasn't walked correctly")
+		t.Error("file folder wasn't walked correctly")
 		fmt.Printf("expected: %v", *expected)
 		fmt.Printf("result: %v", *result)
 	}
 }
 
-func TestGetSubTreeHandlesError(t *testing.T) {
+func TestWalkFolderHandlesError(t *testing.T) {
 	failing := func(path string) ([]os.FileInfo, error) {
 		return []os.FileInfo{}, errors.New("Not found")
 	}
 	result := WalkFolder("xyz", failing, map[string]struct{}{})
 	if !reflect.DeepEqual(*result, File{}) {
-		t.Error("GetSubTree didn't return emtpy file on ReadDir failure")
+		t.Error("WalkFolder didn't return emtpy file on ReadDir failure")
 	}
 }
 

--- a/core/processor.go
+++ b/core/processor.go
@@ -5,12 +5,12 @@ import (
 	"sync"
 )
 
-func PrepareTree(tree *File, limit int64) error {
-	PruneTree(tree, limit)
-	if len(tree.Files) == 0 {
-		return fmt.Errorf("the folder '%s' doesn't contain any files bigger than %dMB", tree.Name, limit/MEGABYTE)
+func ProcessFolder(folder *File, limit int64) error {
+	pruneFolder(folder, limit)
+	if len(folder.Files) == 0 {
+		return fmt.Errorf("the folder '%s' doesn't contain any files bigger than %dMB", folder.Name, limit/MEGABYTE)
 	}
-	SortDesc(tree)
+	SortDesc(folder)
 	return nil
 }
 

--- a/core/processor_test.go
+++ b/core/processor_test.go
@@ -6,24 +6,24 @@ import (
 	"testing"
 )
 
-func TestPrepareTree(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 10), NewTestFile("c", 50), NewTestFile("d", 70))
-	PrepareTree(tree, 30)
+func TestProcessFolder(t *testing.T) {
+	folder := NewTestFolder("a", NewTestFile("b", 10), NewTestFile("c", 50), NewTestFile("d", 70))
+	ProcessFolder(folder, 30)
 	c := &File{"c", nil, 50, false, []*File{}}
 	d := &File{"d", nil, 70, false, []*File{}}
 	a := &File{"a", nil, 130, true, []*File{d, c}}
 	d.Parent = a
 	c.Parent = a
-	if !reflect.DeepEqual(*tree, *a) {
-		t.Error("PrepareTree didn't prune and sort tree")
+	if !reflect.DeepEqual(*folder, *a) {
+		t.Error("ProcessFoler didn't prune and sort folder")
 	}
 }
 
-func TestPrepareTreeShouldFailWithSmallFiles(t *testing.T) {
-	tree := NewTestFolder("a", NewTestFile("b", 70))
-	err := PrepareTree(tree, 80)
+func TestProcessFolderShouldFailWithSmallFiles(t *testing.T) {
+	folder := NewTestFolder("a", NewTestFile("b", 70))
+	err := ProcessFolder(folder, 80)
 	if err == nil {
-		t.Error("PrepareTree didn't result in error when run on folder with too small files")
+		t.Error("ProcessFolder didn't result in error when run on folder with too small files")
 	}
 }
 
@@ -31,10 +31,10 @@ func TestStartProcessing(t *testing.T) {
 	commands := make(chan Executer)
 	states := make(chan State, 2)
 	lastStateChan := make(chan<- *State, 1)
-	tree := NewTestFolder("a", NewTestFile("b", 10), NewTestFile("c", 50))
+	folder := NewTestFolder("a", NewTestFile("b", 10), NewTestFile("c", 50))
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go StartProcessing(tree, commands, states, lastStateChan, &wg)
+	go StartProcessing(folder, commands, states, lastStateChan, &wg)
 	commands <- Down{}
 	close(commands)
 	state := <-states
@@ -55,8 +55,8 @@ func TestDoesntProcessInvalidCommand(t *testing.T) {
 	lastStateChan := make(chan<- *State, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	tree := NewTestFolder("a", NewTestFile("b", 10), NewTestFile("c", 50))
-	go StartProcessing(tree, commands, states, lastStateChan, &wg)
+	folder := NewTestFolder("a", NewTestFile("b", 10), NewTestFile("c", 50))
+	go StartProcessing(folder, commands, states, lastStateChan, &wg)
 	<-states
 	commands <- Enter{}
 	close(commands)

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -23,11 +23,11 @@ func NewTestFile(name string, size int64) *File {
 
 // FindTestFile helps testing by returning first occurance of file with given name.
 // Never use in produciton code!
-func FindTestFile(tree *File, name string) *File {
-	if tree.Name == name {
-		return tree
+func FindTestFile(folder *File, name string) *File {
+	if folder.Name == name {
+		return folder
 	}
-	for _, file := range tree.Files {
+	for _, file := range folder.Files {
 		result := FindTestFile(file, name)
 		if result != nil {
 			return result

--- a/core/test_utils_test.go
+++ b/core/test_utils_test.go
@@ -27,11 +27,11 @@ func TestBuildFolderWithFile(t *testing.T) {
 	e.Parent = d
 	build := NewTestFolder("d", NewTestFile("e", 100))
 	if !reflect.DeepEqual(d, build) {
-		t.Errorf("Tree %v is not as expected: %v", d, build)
+		t.Errorf("Folder %v is not as expected: %v", d, build)
 	}
 }
 
-func TestBuildTree(t *testing.T) {
+func TestBuildComplexFolder(t *testing.T) {
 	e := &File{"e", nil, 100, false, []*File{}}
 	d := &File{"d", nil, 100, true, []*File{e}}
 	e.Parent = d
@@ -48,14 +48,14 @@ func TestBuildTree(t *testing.T) {
 }
 
 func TestFindTestFile(t *testing.T) {
-	tree := NewTestFolder("a",
+	folder := NewTestFolder("a",
 		NewTestFolder("b",
 			NewTestFile("c", 10),
 			NewTestFile("d", 100),
 		),
 	)
-	expected := tree.Files[0].Files[1]
-	foundFile := FindTestFile(tree, "d")
+	expected := folder.Files[0].Files[1]
+	foundFile := FindTestFile(folder, "d")
 	if !reflect.DeepEqual(foundFile, expected) {
 		t.Error("FindTestFile didn't find correct file")
 	}

--- a/core/tree_manipulation.go
+++ b/core/tree_manipulation.go
@@ -10,21 +10,21 @@ func (f bySizeDesc) Len() int           { return len(f) }
 func (f bySizeDesc) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
 func (f bySizeDesc) Less(i, j int) bool { return f[i].Size > f[j].Size }
 
-func SortDesc(tree *File) {
-	sort.Sort(bySizeDesc(tree.Files))
-	for _, file := range tree.Files {
+func SortDesc(folder *File) {
+	sort.Sort(bySizeDesc(folder.Files))
+	for _, file := range folder.Files {
 		SortDesc(file)
 	}
 }
 
-func PruneTree(tree *File, limit int64) {
+func pruneFolder(folder *File, limit int64) {
 	prunedFiles := []*File{}
-	for _, file := range tree.Files {
+	for _, file := range folder.Files {
 		if file.Size >= limit {
-			PruneTree(file, limit)
+			pruneFolder(file, limit)
 			prunedFiles = append(prunedFiles, file)
 		}
 	}
-	tree.Files = prunedFiles
+	folder.Files = prunedFiles
 
 }

--- a/core/tree_manipulation_test.go
+++ b/core/tree_manipulation_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-func TestSortTree(t *testing.T) {
-	testTree := NewTestFolder("b",
+func TestSortFolder(t *testing.T) {
+	folder := NewTestFolder("b",
 		NewTestFile("c", 100),
 		NewTestFolder("d",
 			NewTestFile("e", 50),
@@ -29,14 +29,14 @@ func TestSortTree(t *testing.T) {
 		NewTestFile("c", 100),
 	)
 
-	SortDesc(testTree)
-	if !reflect.DeepEqual(testTree, expected) {
-		t.Errorf("tree not sorted correctly\ntree %v\nnot as expected %v", testTree, expected)
+	SortDesc(folder)
+	if !reflect.DeepEqual(folder, expected) {
+		t.Errorf("folder not sorted correctly\nfolder %v\nnot as expected %v", folder, expected)
 	}
 }
 
-func TestPruneTree(t *testing.T) {
-	testTree := &File{"b", nil, 260, true, []*File{
+func TestPruneFolder(t *testing.T) {
+	folder := &File{"b", nil, 260, true, []*File{
 		&File{"c", nil, 100, false, []*File{}},
 		&File{"d", nil, 160, true, []*File{
 			&File{"e", nil, 50, false, []*File{}},
@@ -53,9 +53,9 @@ func TestPruneTree(t *testing.T) {
 			&File{"g", nil, 80, true, []*File{}},
 		}},
 	}}
-	PruneTree(testTree, 60)
-	if !reflect.DeepEqual(testTree, expected) {
-		t.Errorf("tree not pruned correctly\ntree %v\nnot as expected %v", testTree, expected)
+	pruneFolder(folder, 60)
+	if !reflect.DeepEqual(folder, expected) {
+		t.Errorf("folder not pruned correctly\nfolder %v\nnot as expected %v", folder, expected)
 	}
 
 }

--- a/godu.go
+++ b/godu.go
@@ -19,18 +19,18 @@ func main() {
 	nullTerminate := flag.Bool("print0", false, "print null-terminated strings")
 	flag.Parse()
 	args := flag.Args()
-	root := "."
+	rootFolderName := "."
 	if len(args) > 0 {
-		root = args[0]
+		rootFolderName = args[0]
 	}
-	root, err := filepath.Abs(root)
+	rootFolderName, err := filepath.Abs(rootFolderName)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
-	log.Printf("godu will walk through `%s` that might take up to few minutes\n", root)
-	tree := core.WalkFolder(root, ioutil.ReadDir, getIgnoredFolders())
-	tree.Name = root
-	err = core.PrepareTree(tree, *limit*core.MEGABYTE)
+	log.Printf("godu will walk through `%s` that might take up to few minutes\n", rootFolderName)
+	rootFolder := core.WalkFolder(rootFolderName, ioutil.ReadDir, getIgnoredFolders())
+	rootFolder.Name = rootFolderName
+	err = core.ProcessFolder(rootFolder, *limit*core.MEGABYTE)
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
@@ -40,8 +40,8 @@ func main() {
 	lastStateChan := make(chan *core.State, 1)
 	var wg sync.WaitGroup
 	wg.Add(3)
-	go core.StartProcessing(tree, commands, states, lastStateChan, &wg)
-	go InteractiveTree(s, states, &wg)
+	go core.StartProcessing(rootFolder, commands, states, lastStateChan, &wg)
+	go InteractiveFolder(s, states, &wg)
 	go ParseCommand(s, commands, &wg)
 	wg.Wait()
 	s.Fini()

--- a/interactive/reporter.go
+++ b/interactive/reporter.go
@@ -11,7 +11,7 @@ type Line struct {
 	IsMarked bool
 }
 
-func ReportTree(folder *core.File, markedFiles map[*core.File]struct{}) []Line {
+func ReportFolder(folder *core.File, markedFiles map[*core.File]struct{}) []Line {
 	report := make([]Line, len(folder.Files))
 	for index, file := range folder.Files {
 		name := file.Name

--- a/interactive/reporter_test.go
+++ b/interactive/reporter_test.go
@@ -7,35 +7,35 @@ import (
 	"github.com/viktomas/godu/core"
 )
 
-func TestReportTree(t *testing.T) {
+func TestReportFolder(t *testing.T) {
 	marked := make(map[*core.File]struct{})
-	testTree := core.NewTestFolder("b",
+	folder := core.NewTestFolder("b",
 		core.NewTestFile("c", 100),
 		core.NewTestFolder("d",
 			core.NewTestFile("e", 50),
 			core.NewTestFile("f", 30),
 		),
 	)
-	marked[testTree.Files[0]] = struct{}{}
+	marked[folder.Files[0]] = struct{}{}
 	expected := []Line{
 		Line{Text: []rune("* 100B c"), IsMarked: true},
 		Line{Text: []rune("   80B d/")},
 	}
-	testTreeAgainstOutput(testTree, marked, expected, t)
+	testFolderAgainstOutput(folder, marked, expected, t)
 }
 
 func TestPrintsEmptyDir(t *testing.T) {
 	marked := make(map[*core.File]struct{})
-	testTree := core.NewTestFolder("", core.NewTestFolder("a"))
+	folder := core.NewTestFolder("", core.NewTestFolder("a"))
 	expected := []Line{
 		Line{Text: []rune("    0B a/")},
 	}
-	testTreeAgainstOutput(testTree, marked, expected, t)
+	testFolderAgainstOutput(folder, marked, expected, t)
 }
 
 func TestFiveCharSize(t *testing.T) {
 	marked := make(map[*core.File]struct{})
-	testTree := core.NewTestFolder("X",
+	folder := core.NewTestFolder("X",
 		core.NewTestFile("o", 1),
 		core.NewTestFile("on", 10),
 		core.NewTestFile("one", 100),
@@ -47,12 +47,12 @@ func TestFiveCharSize(t *testing.T) {
 		Line{Text: []rune("  100B one")},
 		Line{Text: []rune(" 1000B one1")},
 	}
-	testTreeAgainstOutput(testTree, marked, ex, t)
+	testFolderAgainstOutput(folder, marked, ex, t)
 }
 
 func TestReportingUnits(t *testing.T) {
 	marked := make(map[*core.File]struct{})
-	testTree := core.NewTestFolder("X",
+	folder := core.NewTestFolder("X",
 		core.NewTestFile("B", 1<<0),
 		core.NewTestFile("K", 1<<10),
 		core.NewTestFile("M", 1048576),
@@ -68,11 +68,11 @@ func TestReportingUnits(t *testing.T) {
 		Line{Text: []rune("    1T T")},
 		Line{Text: []rune("    1P P")},
 	}
-	testTreeAgainstOutput(testTree, marked, ex, t)
+	testFolderAgainstOutput(folder, marked, ex, t)
 }
 
-func testTreeAgainstOutput(testTree *core.File, marked map[*core.File]struct{}, expected []Line, t *testing.T) {
-	result := ReportTree(testTree, marked)
+func testFolderAgainstOutput(folder *core.File, marked map[*core.File]struct{}, expected []Line, t *testing.T) {
+	result := ReportFolder(folder, marked)
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("expected:\n%vbut got:\n%v", expected, result)
 	}

--- a/state_model.go
+++ b/state_model.go
@@ -13,7 +13,7 @@ type VisualState struct {
 }
 
 func NewVisualState(state core.State) VisualState {
-	lines := interactive.ReportTree(state.Folder, state.MarkedFiles)
+	lines := interactive.ReportFolder(state.Folder, state.MarkedFiles)
 	xbound := 0
 	ybound := len(lines)
 	for index, line := range lines {

--- a/state_presenter.go
+++ b/state_presenter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/viktomas/godu/core"
 )
 
-func InteractiveTree(s tcell.Screen, states chan core.State, wg *sync.WaitGroup) {
+func InteractiveFolder(s tcell.Screen, states chan core.State, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for {
 		state, more := <-states


### PR DESCRIPTION
The only 2 names for File are folder or file where file refers to leafs
of file tree.

fixes #56 

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

