### PR TITLE
Fix contributing guide reference in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
-- [ ] I've read [Contribution guide](../CONTRIBUTING.md)
+- [ ] I've read [Contribution guide](https://github.com/viktomas/godu/blob/master/CONTRIBUTING.md)
 - [ ] I've tested everything that doesn't relate to tcell.Screen API
 


### PR DESCRIPTION
The relative path works only when looking at this md file in git, not in PR

- [x] I've read [Contribution guide](../CONTRIBUTING.md)
--this line is the exact issue, the link doesn't work in PR
- [x] I've tested everything that doesn't relate to tcell.Screen API

