### PR TITLE
add freebsd as an OS in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
       - linux
       - windows
       - darwin
+      - freebsd
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
- [x] I've read [Contribution guide](https://github.com/viktomas/godu/blob/master/CONTRIBUTING.md)
- [x] I've tested everything that doesn't relate to tcell.Screen API

This MR adds support for releasing binaries for the `freebsd` OS 

Related to #91

